### PR TITLE
【機能移植+α】ダイアログのサイズを大きくする機能

### DIFF
--- a/ScombZ Utilities/js/styleDialog.js
+++ b/ScombZ Utilities/js/styleDialog.js
@@ -2,6 +2,52 @@
 /* styleDialog.js */
 function styleDialog(){
     'use strict';
-    
-    console.log("test");
+    const dialogObserver = new MutationObserver((mutations) => {
+        const $infoDialog = document.querySelector('[aria-describedby="infoDetailView"]');
+        const $progressDialog = document.querySelector('[aria-describedby="progress_dialog"]');
+        const $notificationDialog = document.querySelector('[aria-describedby="info_detail_view2"]');
+        const $courseDialog = document.querySelector('[aria-describedby="info_detail_view"]');
+
+        const $widgetOverlay = document.getElementsByClassName('ui-widget-overlay')[0];
+
+        const $contentAppendCSSText = 'max-height: calc(90vh - 40px)!important; height: calc(90vh - 40px);';
+        const $dialogAppendCSSText = 'position: fixed; inset: 0; margin: auto; width: 960px; height: fit-content;';
+
+        //  ポータルホームのダイアログの処理
+        if ($infoDialog && !$progressDialog && $infoDialog.style.display !== 'none'){
+            document.getElementById('infoDetailView').style.cssText += $contentAppendCSSText;
+            $infoDialog.style.cssText += $dialogAppendCSSText;
+            $widgetOverlay.addEventListener('click', function(){
+                $infoDialog.querySelector('.commonDialogButtonArea button.under-btn.btn-color.btn-txt.ui-button.ui-corner-all.ui-widget').click();
+            }, { once: true });
+        }
+
+        //  お知らせのダイアログの処理
+        if ($notificationDialog && $notificationDialog.style.display !== 'none'){
+            document.getElementById('info_detail_view2').style.cssText += $contentAppendCSSText;
+            $notificationDialog.style.cssText += $dialogAppendCSSText;
+            $widgetOverlay.addEventListener('click', function(){
+                $notificationDialog.querySelector('.commonDialogButtonArea button.under-btn.btn-color.btn-txt.ui-button.ui-corner-all.ui-widget').click();
+            }, { once: true });
+        }
+
+        //  LMSの授業詳細ページ＆コミュニティ詳細ページのダイアログの処理
+        if ($courseDialog && $courseDialog.style.display !== 'none'){
+            document.getElementById('info_detail_view').style.cssText += $contentAppendCSSText;
+            $courseDialog.style.cssText += $dialogAppendCSSText;
+            $widgetOverlay.addEventListener('click', function(){
+                $courseDialog.querySelector('.commonDialogButtonArea button.under-btn.btn-color.btn-txt.ui-button.ui-corner-all.ui-widget').click();
+            }, { once: true });
+        }
+    });
+
+    const config = {
+        childList: true
+    }
+
+    const target = document.body;
+
+    dialogObserver.observe(target, config);
+
+    return;
 }


### PR DESCRIPTION
#10 Scombetterとの統合「お知らせダイアログ拡大表示」

## 機能の追加（移植）
- styleDialog.jsにて、お知らせダイアログのサイズを大きくする機能を追加しました

## Scombetterからの変更点
- jQueryに依存しません
- ダイアログのサイズを縦方向だけでなく、横方向にも拡大するようにスタイルの設定を行いました
- ダイアログの外側の灰色の部分をクリックすることでもダイアログを閉じられるようになりました

## 心配事
- 少々変数の命名規則がぐちゃぐちゃになってしまっているかもしれないので問題があれば修正します