### PR TITLE
バグ修正、表示修正

### DIFF
--- a/ScombZ Utilities/js/addSubTimetable.js
+++ b/ScombZ Utilities/js/addSubTimetable.js
@@ -2,7 +2,7 @@
 /* addSubTimetable.js */
 
 //LMS取得&表示
-function subTimetable($timetableDisplay,$tasklistDisplay,$$version){
+function subTimetable($timetableDisplay,$tasklistDisplay,$$version,$$reacquisitionMin){
     'use strict';
     if(document.getElementById('pageMain') === null){
         return;
@@ -21,8 +21,18 @@ function subTimetable($timetableDisplay,$tasklistDisplay,$$version){
     }
     if( $tasklistDisplay === true ){
         console.log('メニュー課題表示を開始します');
-        displayTaskListsOnGrayLayer();
-        console.log('メニュー横に課題を表示しました');
+        chrome.storage.local.get({
+            TaskGetTime: 0
+        },function(items){
+            if(Number(Date.now()) > Number(items.TaskGetTime) + $$reacquisitionMin * 1000 * 60 ){
+                setTimeout(function(){
+                    displayTaskListsOnGrayLayer();
+                },1000);
+            }else{
+            displayTaskListsOnGrayLayer();
+            }
+            console.log('メニュー横に課題を表示しました');
+        });
     }
     return;
 }
@@ -225,7 +235,7 @@ function displayGrayLayer($$version){
 //課題一覧の表示
 function displayTaskListsOnGrayLayer(){
     chrome.storage.local.get({
-        TaskGetTime: null,
+        TaskGetTime: 0,
         tasklistData: null,
         specialSubj: 0,
         tasklistTranslate: 0,
@@ -251,9 +261,6 @@ function displayTaskListsOnGrayLayer(){
             }
             //メイン生成部分
             let kadaiListHTML="";
-            if(!$tasklistObj[0]){
-                return;
-            }
             if(!$tasklistObj[1] && $tasklistObj[0].data === null){
                 kadaiListHTML +=`<div class="subk-line">未提出課題は存在しないか、取得できません。</div>`;
             }else{
@@ -305,7 +312,7 @@ function displayTaskListsOnGrayLayer(){
                     transform: translateY(${items.tasklistTranslate}px);
                     background: rgba(255,255,255,0.5);
                     width: 60vw;
-                    min-width: 500px;
+                    min-width: 550px;
                     padding: 2px;
                 }
                 .task-get-time{

--- a/ScombZ Utilities/js/addSubTimetable.js
+++ b/ScombZ Utilities/js/addSubTimetable.js
@@ -319,6 +319,8 @@ function displayTaskListsOnGrayLayer(){
                     font-weight: normal;
                     font-size: 80%;
                     float:right;
+                    text-decoration:none;
+                    color:#222;
                 }
                 .subk-box{
                     margin:0;
@@ -352,8 +354,12 @@ function displayTaskListsOnGrayLayer(){
                     padding:2px 2px 0px 2px;
                     font-size:14px;
                     margin-left:30px;
+                    max-width:100%;
+                    white-space: nowrap; 
+                    overflow: hidden; 
+                    text-overflow: ellipsis; 
                 }
-                div.subk-link:hover{
+                a.subk-link:hover{
                     background:rgba(0,0,100,0.1);
                 }
                 a.subk-link{
@@ -374,8 +380,9 @@ function displayTaskListsOnGrayLayer(){
                     width:30%;
                     float:left
                 }
-                .subk-column(3n+2){
+                .subk-column:nth-child(3n+2){
                     min-width:160px;
+                    width:calc(70% - 260px);
                 }
                 .relative-deadline-time{
                     font-size:80%;
@@ -386,17 +393,23 @@ function displayTaskListsOnGrayLayer(){
                     .relative-deadline-time{
                         display:none;
                     }
+                    .subk-column:nth-child(3n+2){
+                        width:calc(70% - 160px);
+                    }
                 }
             </style>
             <div class="subtimetableBody" id="subTaskList">
             <div class="subk-box">
-                <div class="subk-head">課題一覧<span class="task-get-time">最終更新:${lastgettime}</span></div>
+                <div class="subk-head">課題一覧<a class="task-get-time" id="reloadTasks" href="javascript:void(0);">最終更新:${lastgettime}</a></div>
                 ${kadaiListHTML}
             </div>
             </div>
             `;
             if(document.getElementById('pageMain'))
                 document.getElementById('pageMain').insertAdjacentHTML('beforeend',kadaiHTML);
+            document.getElementById('reloadTasks').addEventListener("click",function(){
+                getTaskLists(1);
+            });
         }
     });
 }

--- a/ScombZ Utilities/js/notepad.js
+++ b/ScombZ Utilities/js/notepad.js
@@ -18,24 +18,9 @@ function notepad(tasklistDisplay){
     }
     return;
 }
-function addNotepad(){
-    return;
-}
-function removeNotepad(){
-    return;
-}
 function displayNotepad(){
     chrome.storage.local.get({
-        notepadData:[
-            {
-                title: "テストメモ",
-                index: "これはテストです。This is Test."
-            },
-            {
-                title: "OSのミニッツペーパー",
-                index:"提出する。"
-            }
-        ],
+        notepadData:[],
         addSubTimetable: true,
         tasklistTranslate: 0,
         specialSubj: 0,
@@ -244,9 +229,11 @@ function displayNotepad(){
             //保存ボタンをクリックしたとき
             if(noteSaveBtn){
                 noteSaveBtn.addEventListener('click',function(){
+                    let noteInputTitleDataEsc = document.getElementById("noteInputTitle").value.replace(/"|<|>/g,' ');
+                    let noteInputIndexDataEsc = document.getElementById("noteInputIndex").value.replace(/"|<|>/g,' ');
                     const newNote = {
-                        title: document.getElementById("noteInputTitle").value,
-                        index: document.getElementById("noteInputIndex").value
+                        title: noteInputTitleDataEsc,
+                        index: noteInputIndexDataEsc
                     };
                     //追加したメモを保存する
                     newNotepadData.push(newNote);
@@ -263,8 +250,8 @@ function displayNotepad(){
                         //すでにメモがあるとき
                         noteLine[noteLine.length-1].insertAdjacentHTML("afterEnd",`
                             <div class="note-line">
-                            <div class="note-title">${document.getElementById("noteInputTitle").value}</div>
-                            <div class="note-index">${document.getElementById("noteInputIndex").value}</div>
+                            <div class="note-title">${noteInputTitleDataEsc}</div>
+                            <div class="note-index">${noteInputIndexDataEsc}</div>
                             <div class="note-kara"></div>
                             </div>
                         `);
@@ -272,8 +259,8 @@ function displayNotepad(){
                         //メモが一個もないとき
                         document.getElementsByClassName("note-head")[0].insertAdjacentHTML("afterEnd",`
                             <div class="note-line">
-                            <div class="note-title">${document.getElementById("noteInputTitle").value}</div>
-                            <div class="note-index">${document.getElementById("noteInputIndex").value}</div>
+                            <div class="note-title">${noteInputTitleDataEsc}</div>
+                            <div class="note-index">${noteInputIndexDataEsc}</div>
                             <div class="note-kara"></div>
                             </div>
                         `);

--- a/ScombZ Utilities/js/notepad.js
+++ b/ScombZ Utilities/js/notepad.js
@@ -229,8 +229,8 @@ function displayNotepad(){
             //保存ボタンをクリックしたとき
             if(noteSaveBtn){
                 noteSaveBtn.addEventListener('click',function(){
-                    let noteInputTitleDataEsc = document.getElementById("noteInputTitle").value.replace(/"|<|>/g,' ');
-                    let noteInputIndexDataEsc = document.getElementById("noteInputIndex").value.replace(/"|<|>/g,' ');
+                    let noteInputTitleDataEsc = document.getElementById("noteInputTitle").value.replace(/"|<|>/g,' ').replace("\n","<br>");
+                    let noteInputIndexDataEsc = document.getElementById("noteInputIndex").value.replace(/"|<|>/g,' ').replace("\n","<br>");
                     const newNote = {
                         title: noteInputTitleDataEsc,
                         index: noteInputIndexDataEsc

--- a/ScombZ Utilities/main.js
+++ b/ScombZ Utilities/main.js
@@ -3,7 +3,7 @@
 (function(){
     'use strict';
     /*  定数  */
-    const $$version = '3.6.0';          //バージョン
+    const $$version = '3.6.2';          //バージョン
     const $$reacquisitionMin = 15;      //再取得までの時間(分)
     /*  定数ここまで  */
     console.log(`Welcome to ScombZ Utilities ver.${$$version}`);
@@ -88,7 +88,7 @@
                 if(items.styleSidemenu === true){
                     styleSidemenu();
                 //メニューを展開したときの時間割 (オフだった場合はグレーレイヤーだけ表示) , メニュー横に課題一覧を表示
-                    subTimetable(items.addSubTimetable , items.tasklistDisplay , $$version);
+                    subTimetable(items.addSubTimetable , items.tasklistDisplay , $$version,$$reacquisitionMin);
                 }
                 //課題一覧取得
                 if( items.tasklistDisplay === true ){

--- a/ScombZ Utilities/main.js
+++ b/ScombZ Utilities/main.js
@@ -4,7 +4,7 @@
     'use strict';
     /*  定数  */
     const $$version = '3.6.2';          //バージョン
-    const $$reacquisitionMin = 15;      //再取得までの時間(分)
+    const $$reacquisitionMin = 20;      //再取得までの時間(分)
     /*  定数ここまで  */
     console.log(`Welcome to ScombZ Utilities ver.${$$version}`);
     

--- a/ScombZ Utilities/manifest.json
+++ b/ScombZ Utilities/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version":3 ,
     "name": "ScombZ Utilities",
-    "version": "3.6.0",
+    "version": "3.6.2",
     "description": "ScombZをカスタムする拡張機能",
     "icons": { 
         "48":  "icons/icon48.png",

--- a/ScombZ Utilities/options/custom.js
+++ b/ScombZ Utilities/options/custom.js
@@ -31,7 +31,7 @@ chrome.storage.local.get({
     //保存
     function saveCss(){
         jsEditor.save();
-        const editorIndex = document.getElementById('editor_js').value;
+        const editorIndex = document.getElementById('editor_js').value.replace(/<\//g,'');
         chrome.storage.local.set({
             customcss : editorIndex
         },function(){


### PR DESCRIPTION
・メモにHTMLタグを入れられるバグ
・メニュー横課題一覧表示で、時刻がはみ出るバグ
・教科別ページで、課題がはみ出るバグ
を修正しました

・課題一覧読み込み時に表示を1秒遅延させることで、読み込み後の課題一覧を直接表示できるようにしました
・課題一覧の最終更新をクリックすることで、手動で更新できるようにしました
・手動更新の追加に伴い、自動取得のスパンを15分から20分に変更しました