### PR TITLE
Yudai1204 bugfix

### DIFF
--- a/ScombZ Utilities/js/addSubTimetable.js
+++ b/ScombZ Utilities/js/addSubTimetable.js
@@ -46,6 +46,11 @@ function han2Zenkaku($str) {
 }
 //LMSから情報を取得してJSON化する関数
 function getSubTimetable(){
+    //時間割じゃなくてスケジュールだったら取得できないので取得しない
+    if(!document.getElementById('displayMode1') || !document.getElementById('displayMode1').checked) {
+        return;
+    }
+    //取得する
     console.log('LMSを取得開始します');
     const $courseList = document.querySelectorAll('.timetable-course-top-btn');
     if($courseList[0]){
@@ -235,8 +240,10 @@ function displayGrayLayer($$version){
 //課題一覧の表示
 function displayTaskListsOnGrayLayer(){
     chrome.storage.local.get({
-        TaskGetTime: 0,
-        tasklistData: null,
+        TaskGetTime: 1,
+        tasklistData: [{
+            data:null
+        }],
         specialSubj: 0,
         tasklistTranslate: 0,
         deadlinemode: 'absolute-relative'

--- a/ScombZ Utilities/js/layout.js
+++ b/ScombZ Utilities/js/layout.js
@@ -241,7 +241,7 @@ function addExtensionSettingsBtn(){
     if($headerBtnArea){
         $headerBtnArea.insertAdjacentHTML("afterBegin",`
         <style>
-        @media (max-width:630px){
+        @media (max-width:650px){
             #link_to_extention{
                 display:none;
             }
@@ -275,6 +275,9 @@ function removeName(){
 function fixHeadShadow(){
     if(document.getElementById("page_head")){
         document.getElementById("page_head").style.boxShadow = "rgb(60 64 67 / 30%) 0px 1px 2px, rgb(60 64 67 / 15%) 0px 2px 6px 2px";
+    }
+    if(document.getElementById("examTimer")){
+        document.getElementById("examTimer").style.boxShadow = "rgb(60 64 67 / 30%) 0px 1px 2px, rgb(60 64 67 / 15%) 0px 2px 6px 2px";
     }
     return;
 }

--- a/ScombZ Utilities/js/styleExam.js
+++ b/ScombZ Utilities/js/styleExam.js
@@ -106,6 +106,14 @@ function styleExam(){
             }
             if(document.querySelector('.page-directlink'))
                 document.querySelector('.page-directlink').remove();
+            //毎分自動保存
+            setInterval(function() {
+                const $saveBtn = document.querySelector(".block-under-area .block-under-area-btn .tempSaveBtn");
+                if($saveBtn){
+                    $saveBtn.click();
+                    console.log("上書き保存 Auto");
+                }
+            },60000);//秒数
             //Ctrl+Sで自動保存
             $(window).bind('keydown', function(e) {
                 if (e.ctrlKey || e.metaKey) {
@@ -115,6 +123,7 @@ function styleExam(){
                         const $saveBtn = document.querySelector(".block-under-area .block-under-area-btn .tempSaveBtn");
                         if($saveBtn){
                             $saveBtn.click();
+                            console.log("上書き保存 ctrl+S");
                         }
                         break;
                     }
@@ -177,7 +186,7 @@ function styleExam(){
         }
         //テストを受け終わった画面
         //すでに受けたテストを参照する画面
-        if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course/examination/take?confirm") || location.href.includes("takeresult")){
+        if(location.href.includes("examination/take?complete")){
             console.log('テスト完了画面');
             document.head.insertAdjacentHTML('beforeEnd',`
             <style>
@@ -191,18 +200,17 @@ function styleExam(){
                 min-width:140px;
                 min-height:50px;
                 box-shadow:none;
+                max-width: 440px;
             }
             </style>
             `);
             if(document.querySelector('.page-directlink'))
                 document.querySelector('.page-directlink').remove();
-            if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course/examination/take?confirm")){
-                //提出完了時にAjax通信をして課題一覧を更新
-                console.log("テスト提出完了ページを検出");
-                setTimeout(function(){
-                    getTaskLists(0);
-                },500);
-            }
+            //提出完了時にAjax通信をして課題一覧を更新
+            console.log("テスト提出完了ページを検出");
+            setTimeout(function(){
+                getTaskLists(0);
+            },500);
         }
     }
     return;

--- a/ScombZ Utilities/js/styleSidemenu.js
+++ b/ScombZ Utilities/js/styleSidemenu.js
@@ -140,7 +140,7 @@ function styleSidemenu(){
             top:0;
             left:0;
             width:100%;
-            minW-width:371px;
+            min-width:371px;
         }
         .sidemenu-head{
             height:60px;
@@ -166,13 +166,16 @@ function styleSidemenu(){
     `);
     //LMSページ飛び出る問題
     if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
-            const reportList = document.getElementById("reportList");
-            if(reportList){
+        const contentsDetails = document.querySelectorAll(".contents-detail");
+        for(const contentsDetail of contentsDetails){
+            if(contentsDetail.parentNode.parentNode && contentsDetail.parentNode.parentNode.classList.contains("block") && contentsDetail.parentNode.parentNode.classList.contains("clearfix")){
                 setTimeout(() =>{
-                reportList.parentNode.style.height = reportList.clientHeight+'px';
-                reportList.parentNode.previousElementSibling.style.height = reportList.clientHeight+'px';
-                },100);
+                    contentsDetail.parentNode.style.height = contentsDetail.clientHeight+'px';
+                    if(contentsDetail.parentNode.previousElementSibling)
+                        contentsDetail.parentNode.previousElementSibling.style.height = contentsDetail.clientHeight+'px';
+                    },300);
             }
+        }
     }
     //ヘッダ中心にアイコンを表示 ヘッダをクリックで一番上へ
     const $pageHead = document.getElementById('page_head');

--- a/ScombZ Utilities/main.js
+++ b/ScombZ Utilities/main.js
@@ -3,7 +3,7 @@
 (function(){
     'use strict';
     /*  定数  */
-    const $$version = '3.6.2';          //バージョン
+    const $$version = '3.6.3';          //バージョン
     const $$reacquisitionMin = 20;      //再取得までの時間(分)
     /*  定数ここまで  */
     console.log(`Welcome to ScombZ Utilities ver.${$$version}`);

--- a/ScombZ Utilities/manifest.json
+++ b/ScombZ Utilities/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version":3 ,
     "name": "ScombZ Utilities",
-    "version": "3.6.2",
+    "version": "3.6.3",
     "description": "ScombZをカスタムする拡張機能",
     "icons": { 
         "48":  "icons/icon48.png",

--- a/ScombZ Utilities/options/options.html
+++ b/ScombZ Utilities/options/options.html
@@ -128,7 +128,7 @@
                 <h3>メニュー横の課題表示(※左メニュースタイル変更必須)</h3>
                 <span style="color:red;font-size: 13px;">※この設定は、左メニューのスタイル変更がオフの場合自動的にオフになります。</span><br>
                 <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="tasklistDisplay"><label class="ItemBox-CheckBox-Label" for="tasklistDisplay"></label>
-                <div class="explains">サイドメニュー展開時に、右のスペースに簡易的なテスト・課題一覧を表示します。<br>この課題一覧は、約15分毎に自動更新され、課題一覧ページに直接飛ぶことでも更新できます。<br>
+                <div class="explains">サイドメニュー展開時に、右のスペースに簡易的なテスト・課題一覧を表示します。<br>この課題一覧は、約20分毎に自動更新され、課題一覧ページに直接飛ぶか、最終更新時刻をクリックすることでも更新できます。<br>
                     <div class="wrap">
                         <label for="label3">▼詳細を見る</label>
                         <input type="checkbox" id="label3" class="wrap-switch" />
@@ -185,10 +185,10 @@
                 </div>
             </div>
             <div class="setting-column">
-                <h3>テストのボタンの変更</h3>
+                <h3>テストのスタイルの変更</h3>
                 <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="exam_btn"><label class="ItemBox-CheckBox-Label" for="exam_btn"></label>
                 <div class="explains">
-                    レポート提出画面と同様に、テスト確認画面や受験画面をユーザビリティに配慮した色や配置にします。<br>また、誤クリックによって入力したデータが消えることを防止するために、受験中では提出ボタン意外の遷移ボタンを押すと「このサイトを離れてもよろしいですか？」という警告を表示するようになります。<br>
+                    レポート提出画面と同様に、テスト確認画面や受験画面をユーザビリティに配慮した色や配置にします。<br>また、誤クリックによって入力したデータが消えることを防止するために、受験中では提出ボタン意外の遷移ボタンを押すと「このサイトを離れてもよろしいですか？」という警告を表示するようになります。<br>そして、テストは1分ごとに自動的に保存されるようになり、Ctrl (Command) + Sキーでも保存ができるようになります。
                 </div>
             </div>
             <div class="setting-column">


### PR DESCRIPTION
**バグ修正**
・LMSが本来取得できない状態でも取得しようとしてエラーが発生するバグを修正しました。
・前回の課題取得時間が初期設定で0となっていて、false判定をして取得しない問題を修正しました
・スタイリングで、拡張機能設定ボタンが飛び出る場合があるので表示限界をページ横幅630pxから650pxに引き上げました
・テストを受け終わった画面の判定が、テスト提出確認画面を判定してしまうバグを修正しました
・画面が極端に横幅を小さくしたときに、メニューを展開すると別のmin-widthが適用されて背景が動いてしまう問題を修正しました
・科目別ページで、コンテンツが飛び出る問題がレポート以外にも発生していたのですべて修正するようにしました
・オプションの説明文が最新版と違う挙動であったため、最新版にあったものに書き直しました

**新機能**
・テストのタイマーにも透明度のある影を適用しました
・テストを毎分自動保存するようにしました