### PR TITLE
[Refactoring]: Address the conflict between ESLint and Prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
         "sourceType": "module"
     },
     "rules": {
+        "eqeqeq": "error",
         "indent": ["error", 4],
         "no-undef": "off",
         "no-unused-vars": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
             "devDependencies": {
                 "eslint": "^8.15.0",
                 "eslint-config-google": "^0.14.0",
+                "eslint-config-prettier": "^8.5.0",
                 "prettier": "^2.6.2"
             }
         },
@@ -957,6 +958,18 @@
             },
             "peerDependencies": {
                 "eslint": ">=5.16.0"
+            }
+        },
+        "node_modules/eslint-config-prettier": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -2533,6 +2546,13 @@
             "version": "0.14.0",
             "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
             "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
+            "dev": true,
+            "requires": {}
+        },
+        "eslint-config-prettier": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
             "dev": true,
             "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "devDependencies": {
         "eslint": "^8.15.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-config-prettier": "^8.5.0",
         "prettier": "^2.6.2"
     },
     "dependencies": {


### PR DESCRIPTION
## 目的

PR #35 において，ESLint と Prettier が競合してしまう状態だったのを修正しました。

## 変更内容

- `eslint-config-prettier` を依存関係として追加しました
- ESLint の [eqeqeq](https://eslint.org/docs/rules/eqeqeq) ルールを有効にしました

## その他

本 PR の merge で意図しない競合状態は解消されるはずですが，もし何らかの確認漏れと思しき箇所を発見されましたら，ご指摘ください。