### PR TITLE
【bugfix】課題配列を取り出す範囲の計算式の修正

### DIFF
--- a/ScombZ Utilities/js/addSubTimetable.js
+++ b/ScombZ Utilities/js/addSubTimetable.js
@@ -321,7 +321,7 @@ function displayTaskListsOnGrayLayer(){
                 kadaiListHTML +=`<div class="subk-line">未提出課題は存在しないか、取得できません。</div>`;
             }else{
                 const nowUnix = Date.now();
-                for(let i=0,j=0; $tasklistObj[i] && i<items.maxTaskDisplay -j; i++){
+                for(let i=0,j=0; $tasklistObj[i] && i<items.maxTaskDisplay +j; i++){
                     //先の課題は表示しない
                     if((Number(Date.parse($tasklistObj[i].deadline)) - Number(nowUnix))/60000 > 60*24*(1+Number(items.undisplayFutureTaskDays))){
                         break;


### PR DESCRIPTION
## 変更
課題一覧の描画処理で，「非表示の課題を検出した分だけ課題データの最大取得範囲を広げる」という意図に反して逆に取得範囲が狭まってしまい「必要数以上に課題が非表示になってしまう」という不具合が発生していたのでループ条件の計算式を修正しました．