### PR TITLE
月/日表示で10月が0月になってしまう問題の修正

### DIFF
--- a/ScombZ Utilities/js/addSubTimetable.js
+++ b/ScombZ Utilities/js/addSubTimetable.js
@@ -338,9 +338,10 @@ function displayTaskListsOnGrayLayer(){
                     if($tasklistObj[i].data === null)continue;
                     //絶対表示
                     deadline = ($tasklistObj[i].deadline.length > 17) ? $tasklistObj[i].deadline : $tasklistObj[i].deadline+":00";
-                    if(items.deadlinemode.includes('absoluteShort'))
+                    if(items.deadlinemode.includes('absoluteShort')){
                         deadline = $tasklistObj[i].deadline.slice(5,-3);
-                        if(deadline.slice(0,1) !== "1")deadline = deadline.slice(1);
+                        if(deadline.slice(0,1) === "0")deadline = deadline.slice(1);
+                    }
                     //相対表示
                     if(items.deadlinemode.includes('relative') && $tasklistObj[i].deadline != "" ){
                         if(items.deadlinemode == 'relative'){


### PR DESCRIPTION
issueにて報告されていた、課題一覧の表示方式を「残り時間 + 月/日 時:分」または「月/日 時:分」にすると、月の十の桁が消えてしまう問題の修正