### PR TITLE
課題数カウントの除外日数を設定できるように

### DIFF
--- a/ScombZ Utilities/js/background.js
+++ b/ScombZ Utilities/js/background.js
@@ -120,6 +120,11 @@ function removeHiddenTasks(tasklist, utilsStorageData){
         && (Number(Date.parse(item.deadline)) - Number(Date.now()))/60000 <= 60*24*(1+Number(utilsStorageData.undisplayFutureTaskDays)));
 }
 
+function removeUncountTasks(tasklist, utilsStorageData){
+    return tasklist.filter(item => 
+        (Number(Date.parse(item.deadline)) - Number(Date.now()))/60000 <= 60*24*(1+Number(utilsStorageData.popupUncountFutureTaskDays)));
+}
+
 function updateBadgeText() {
     chrome.storage.local.get({
         tasklistData: [],
@@ -127,6 +132,7 @@ function updateBadgeText() {
         manualTasklist: [],
         hiddenTasks: [],
         undisplayFutureTaskDays: 365,
+        popupUncountFutureTaskDays: 365,
         popupBadge: true,
     }, function(items) {
         if(chrome.action){
@@ -135,7 +141,7 @@ function updateBadgeText() {
                 return;
             }
 
-            let t = removeHiddenTasks(getMergedTaskList(items), items);
+            let t = removeUncountTasks(removeHiddenTasks(getMergedTaskList(items), items), items);
 
             if(t.length > 0){
                 const rd = (Number(Date.parse(t[0].deadline)) - Number(Date.now()))/60000;
@@ -153,7 +159,7 @@ function updateBadgeText() {
                 return;
             }
 
-            let t = removeHiddenTasks(getMergedTaskList(items), items);
+            let t = removeUncountTasks(removeHiddenTasks(getMergedTaskList(items), items), items);
 
             if(t.length > 0){
                 const rd = (Number(Date.parse(t[0].deadline)) - Number(Date.now()))/60000;

--- a/ScombZ Utilities/options/options.html
+++ b/ScombZ Utilities/options/options.html
@@ -654,6 +654,24 @@
                     未提出の課題の個数をバッジに表示します。
                 </div>
             </div>
+            <div class="setting-column">
+                <h3>一定より先の課題をバッジにカウントしない</h3><span class="id-explain">popupUncountFutureTaskDays</span>
+                <div class="explains">
+                    未提出の課題の個数をバッジに表示する機能で、2週間後など先の課題をカウントから除外できます。ここではカウントする限度の日数を設定できます。<br />
+                    ※この数を超える課題は、存在していても表示されません。課題がなくなったわけではないことに注意してください。
+                </div>
+                <div class="input-box">
+                    <input type="number" id="popupUncountFutureTaskDays">日以内のみカウントする
+                </div>
+                <button type="button" class="saveBtn">保存する</button>
+            </div>
+            <div class="setting-column">
+                <h3>カウントから除外した課題を暗くする</h3><span class="id-explain">popupDarkenUncountedTasks</span>
+                <input class="ItemBox-CheckBox-Input" type="checkbox" id="popupDarkenUncountedTasks"><label class="ItemBox-CheckBox-Label" for="popupDarkenUncountedTasks"></label>
+                <div class="explains">
+                    「一定より先の課題をバッジにカウントしない」設定でカウントから除外された課題の背景色を暗くします。
+                </div>
+            </div>
 
             <hr>
             <h2>実験的な設定</h2>

--- a/ScombZ Utilities/options/options.js
+++ b/ScombZ Utilities/options/options.js
@@ -51,6 +51,8 @@ const defaultOptions = {
     popupBadge: true,
     popupTasksTab: true,
     popupTasksLinks: true,
+    popupUncountFutureTaskDays: 365,
+    popupDarkenUncountedTasks: true,
     maxWidthPx:{
         subj: 1280,
         lms: 1280,
@@ -131,6 +133,8 @@ function save_options() {
     const popupBadge = document.getElementById('popupBadge').checked;
     const popupTasksTab = document.getElementById('popupTasksTab').checked;
     const popupTasksLinks = document.getElementById('popupTasksLinks').checked;
+    const popupUncountFutureTaskDays = document.getElementById('popupUncountFutureTaskDays').value;
+    const popupDarkenUncountedTasks = document.getElementById('popupDarkenUncountedTasks').checked;
     const gasURL = document.getElementById('gasURL').value;
     const gasCal = document.getElementById('gasCal').checked;
     const gasTodo = document.getElementById('gasTodo').checked;
@@ -187,6 +191,8 @@ function save_options() {
         popupBadge : popupBadge,
         popupTasksTab : popupTasksTab,
         popupTasksLinks : popupTasksLinks,
+        popupUncountFutureTaskDays : popupUncountFutureTaskDays,
+        popupDarkenUncountedTasks : popupDarkenUncountedTasks,
         maxWidthPx:{
             subj: subjWidth,
             lms: lmsWidth,
@@ -275,6 +281,8 @@ function save_options() {
         document.getElementById('popupBadge').checked = items.popupBadge;
         document.getElementById('popupTasksTab').checked = items.popupTasksTab;
         document.getElementById('popupTasksLinks').checked = items.popupTasksLinks;
+        document.getElementById('popupUncountFutureTaskDays').value = items.popupUncountFutureTaskDays;
+        document.getElementById('popupDarkenUncountedTasks').checked = items.popupDarkenUncountedTasks;
         document.getElementById('gasURL').value = items.gasURL;
         document.getElementById('gasCal').checked = items.gasCal;
         document.getElementById('gasTodo').checked = items.gasTodo;

--- a/ScombZ Utilities/popup/popup.css
+++ b/ScombZ Utilities/popup/popup.css
@@ -203,6 +203,9 @@ h1{
 .a-few-days.highlightMark .task-deadline{
     color: #f22;
 }
+.uncounted.highlightMark{
+    background: #f0f0f0;
+}
 .relative-deadline-time{
     margin-right: 10px;
 }

--- a/ScombZ Utilities/popup/popup.js
+++ b/ScombZ Utilities/popup/popup.js
@@ -95,6 +95,11 @@ function removeHiddenTasks(tasklist, utilsStorageData){
         && (Number(Date.parse(item.deadline)) - Number(Date.now()))/60000 <= 60*24*(1+Number(utilsStorageData.undisplayFutureTaskDays)));
 }
 
+function removeUncountTasks(tasklist, utilsStorageData){
+    return tasklist.filter(item => 
+        (Number(Date.parse(item.deadline)) - Number(Date.now()))/60000 <= 60*24*(1+Number(utilsStorageData.popupUncountFutureTaskDays)));
+}
+
 function initPopupTimetable(){
     chrome.storage.local.get({
         timetableData: null,
@@ -109,6 +114,8 @@ function initPopupTimetable(){
         popupTasksLinks: true,
         hiddenTasks: [],
         undisplayFutureTaskDays: 365,
+        popupUncountFutureTaskDays: 365,
+        popupDarkenUncountedTasks: true,
         highlightDeadline : true,
     }, function(item){
         if(item.timetableData === null){
@@ -176,7 +183,7 @@ function _createWeekdayTabsElement(utilsStorageData, weekday){
         });
 
         let taskBadgeElement = document.createElement('span');
-        taskBadgeElement.innerText = removeHiddenTasks(getMergedTaskList(utilsStorageData), utilsStorageData).length;
+        taskBadgeElement.innerText = removeUncountTasks(removeHiddenTasks(getMergedTaskList(utilsStorageData), utilsStorageData), utilsStorageData).length;
         taskBadgeElement.classList = 'badge';
 
         taskTabElement.appendChild(taskBadgeElement);
@@ -331,6 +338,9 @@ function _createTaskListElement(utilsStorageData){
                 }else if(relativeDeadline < 60*24*7){
                     highlightMark = 'a-week highlightMark';
                 }
+                if(utilsStorageData.popupDarkenUncountedTasks && relativeDeadline >= 60*24*(1 + Number(utilsStorageData.popupUncountFutureTaskDays))){
+                    highlightMark = 'uncounted ' + highlightMark;
+                }
             }
             //link生成
             let subjlink = "",tasklink = "";
@@ -415,6 +425,8 @@ function _createTaskListElement(utilsStorageData){
                 popupTasksLinks: true,
                 hiddenTasks: [],
                 undisplayFutureTaskDays: 365,
+                popupUncountFutureTaskDays: 365,
+                popupDarkenUncountedTasks: true,
                 highlightDeadline : true,
             }, function(item){
                 renderWeekTimetable(item, 0);


### PR DESCRIPTION
## 概要
ポップアップについて、バッジにカウントする課題を残り日数に応じて制限する機能を追加しました。

## 追加された設定項目
### ポップアップ設定
`popupUncountFutureTaskDays` (デフォルト:365)  
未提出の課題の個数をバッジに表示する機能で、設定した日数に応じて課題をカウント対象から除外します。

`popupDarkenUncountedTasks` (デフォルト:true)  
trueの場合、カウント対象外となった課題の背景色を暗くします。

## スクリーンショット
![image](https://user-images.githubusercontent.com/61535180/196919430-4c24e43b-08d5-4f90-a805-56fd90d7b9ec.png)
日数設定を「14日」にした場合