### PR TITLE
[Feature] 「科目トップ」ページのタイトルに科目名を挿入する

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 indent_size = 4
 indent_style = space
 insert_final_newline = true

--- a/ScombZ Utilities/js/modifyCoursePageTitle.js
+++ b/ScombZ Utilities/js/modifyCoursePageTitle.js
@@ -1,0 +1,15 @@
+function modifyCoursePageTitle() {
+    const isCourseTopPage =
+        location.href.split(location.search).join('') ===
+        'https://scombz.shibaura-it.ac.jp/lms/course'
+    const courseTitle = document.querySelector(
+        '#courseTopForm > div.course-header > div:nth-child(1) > div.course-title-txt.course-view-header-txt'
+    )
+    if (isCourseTopPage && courseTitle) {
+        // 科目名
+        const courseName = courseTitle.textContent.split(' ')[2]
+
+        // 「科目名 - 科目トップ」のような表示にする
+        document.title = `${courseName} - ${document.title}`
+    }
+}

--- a/ScombZ Utilities/js/modifyCoursePageTitle.js
+++ b/ScombZ Utilities/js/modifyCoursePageTitle.js
@@ -7,7 +7,7 @@ function modifyCoursePageTitle() {
     )
     if (isCourseTopPage && courseTitle) {
         // 科目名
-        const courseName = courseTitle.textContent.split(' ')[2]
+        const courseName = courseTitle.textContent.split(' ').at(-1)
 
         // 「科目名 - 科目トップ」のような表示にする
         document.title = `${courseName} - ${document.title}`

--- a/ScombZ Utilities/main.js
+++ b/ScombZ Utilities/main.js
@@ -8,7 +8,7 @@
     const $$reacquisitionMin = 20;      //再取得までの時間(分)
     /*  定数ここまで  */
     console.log(`Welcome to ScombZ Utilities ver.${$$version}`);
-    
+
     /* 設定読み込み*/
     //初期状態（設定が保存されていない場合に適用される）
     const defaults = {
@@ -41,19 +41,20 @@
             remomveDirectLink: true,    //ダイレクトリンクを消す
             dadbugFix: true,            //ドラッグ&ドロップで提出できないバグを修正
             attendance: 'none',         //出席記録を消す
-            pastSurvey: true,           //過去のアンケート    
+            pastSurvey: true,           //過去のアンケート
             adjustTimetableData:{       // LMSの調整
                 eraseSat: false,        // 土曜日を消す
                 erase6: false,          // 6限を消す
                 erase7: false,          // 7限を消す
                 dispClassroom: false,   // 講師名表示を教室表示にする
-                timetableCentering: false // 時間割のセンタリング 
+                timetableCentering: false // 時間割のセンタリング
             },
             subjectList : '12345678',   //要素の並び替え
             materialTop : false,        //教材の位置
             materialHide : true,        //教材を閉じる
             reportHide : false,          //課題を非表示
             testHide : false,            //テストを非表示
+            modifyCoursePageTitle: true, // 科目トップページに科目名を追加する
             materialTopDetail : 'first',
             materialHideDetail : 'none',
             reportHideDetail : 'all'
@@ -88,7 +89,7 @@
                 setTimeout(function(){
                     document.documentElement.style.visibility = '';
                 },300);
-                
+
                 //設定ボタンを追加
                 addExtensionSettingsBtn();
                 //帰ってきて芝猫
@@ -140,7 +141,7 @@
                 if(items.changeReportBtn === true){
                     changeReportBtn();
                 }
-                
+
                 //ログアウト画面の変更
                 if(items.changeLogout === true){
                     changeLogout();
@@ -153,7 +154,7 @@
                 if(items.pageTopBtn === true){
                     remomvePageTop();
                 }
-                
+
                 //ホイールクリックをできる機能
                 if(items.mouseDown === true){
                 mouseEvents();
@@ -180,15 +181,15 @@
                     notepad(items.tasklistDisplay);
                     addMarkdownToSubj();
                 }
-                
+
                 //LMSの調整
                 adjustTimetable(items.adjustTimetableData, items.addSubTimetable);
-                
+
                 //D&Dで課題提出
                 if(items.ddSubmission === true){
                     ddSub();
                 }
-                
+
                 //通知を削除するボタン
                 if(items.updateClear === true){
                     updateClear();
@@ -228,6 +229,10 @@
                 //テストの非表示
                 if(items.testHide === true){
                     hideTest('over');
+                }
+                //ページタイトルに科目名を追加する
+                if(items.modifyCoursePageTitle === true){
+                    modifyCoursePageTitle();
                 }
                 //ダークモードの適用
                 darkmodeLayout(items.darkmode);

--- a/ScombZ Utilities/manifest.json
+++ b/ScombZ Utilities/manifest.json
@@ -3,9 +3,9 @@
     "name": "ScombZ Utilities",
     "version": "3.15.2",
     "description": "ScombZをカスタムする拡張機能",
-    "icons": { 
+    "icons": {
         "48":  "icons/icon48.png",
-        "128": "icons/icon128.png" 
+        "128": "icons/icon128.png"
     },
     "action":{
         "default_title":"ScombZ Utilities",
@@ -51,7 +51,8 @@
                 "js/attendance.js",
                 "js/exportCalender.js",
                 "js/getnews.js",
-                "js/layoutSubject.js"
+                "js/layoutSubject.js",
+                "js/modifyCoursePageTitle.js"
             ]
         }
     ],

--- a/ScombZ Utilities/manifestFirefox.json
+++ b/ScombZ Utilities/manifestFirefox.json
@@ -3,9 +3,9 @@
     "name": "ScombZ Utilities",
     "version": "3.15.2",
     "description": "ScombZをカスタムする拡張機能",
-    "icons": { 
+    "icons": {
         "48":  "icons/icon48.png",
-        "128": "icons/icon128.png" 
+        "128": "icons/icon128.png"
     },
     "browser_action":{
         "default_title":"ScombZ Utilities",
@@ -50,7 +50,8 @@
                 "js/attendance.js",
                 "js/exportCalender.js",
                 "js/getnews.js",
-                "js/layoutSubject.js"
+                "js/layoutSubject.js",
+                "js/modifyCoursePageTitle.js"
             ]
         }
     ],

--- a/ScombZ Utilities/options/options.html
+++ b/ScombZ Utilities/options/options.html
@@ -496,7 +496,7 @@
                 <div class="explains">
                     LMS画面で、講義名の下に表示される講師名を削除し、教室表示に置き換えます。長すぎる教室名は途中までしか表示されませんが、変更前と同様に、ホバーするとすべての教室が確認できます。
                 </div>
-            </div>            
+            </div>
             <div class="setting-column">
                 <h3>LMSセンタリング</h3><span class="id-explain">timetableCentering</span>
                 <input class="ItemBox-CheckBox-Input"  type="checkbox" id="timetableCentering"><label class="ItemBox-CheckBox-Label" for="timetableCentering"></label>
@@ -600,7 +600,14 @@
                     提出期限を過ぎたテストを非表示にします。<br>
                     また、一次的に再表示するボタンも追加します。
                 </div>
-            </div>   
+            </div>
+            <div class="setting-column">
+                <h3>ページタイトルに科目名を表示</h3>
+                <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="modifyCoursePageTitle"><label class="ItemBox-CheckBox-Label" for="modifyCoursePageTitle"></label>
+                <div class="explains">
+                    科目トップのページタイトルに科目名を表示します。大量にタブを開いている場合に探しやすくなり、便利です。
+                </div>
+            </div>
 
             <hr>
             <h2>ポップアップ設定</h2>
@@ -869,7 +876,7 @@
             <p>version: <span id="version"></span></p>
             <p><a class="links" href="https://chrome.google.com/webstore/detail/scombz-utilities/iejnanaabfgocfjbnmhkfheghbkanibj?hl=ja">Chrome Web Store</a></p>
             <p><a class="links" href="https://github.com/yudai1204/ScombZ-Utilities">GitHub</a></p>
-            <p>使用ライブラリ : 
+            <p>使用ライブラリ :
                 <ul style="margin-left:40px;margin-bottom: 5px;">
                 <li>encording.js</li>
                 <li>jQuery</li>

--- a/ScombZ Utilities/options/options.js
+++ b/ScombZ Utilities/options/options.js
@@ -63,6 +63,7 @@ const defaultOptions = {
     materialHide : true,
     reportHide : false,
     testHide : false,
+    modifyCoursePageTitle: true,
     materialTopDetail : 'first',
     materialHideDetail : 'none',
     reportHideDetail : 'all',
@@ -126,6 +127,7 @@ function save_options() {
     const materialHide = document.getElementById('materialHide').checked;
     const reportHide = document.getElementById('reportHide').checked;
     const testHide = document.getElementById('testHide').checked;
+    const modifyCoursePageTitle = document.getElementById('modifyCoursePageTitle').checked;
     const materialTopDetail = document.getElementById('materialTopDetail').value;
     const materialHideDetail = document.getElementById('materialHideDetail').value;
     const reportHideDetail = document.getElementById('reportHideDetail').value;
@@ -203,6 +205,7 @@ function save_options() {
         materialHide : materialHide,
         reportHide : reportHide,
         testHide : testHide,
+        modifyCoursePageTitle: modifyCoursePageTitle,
         materialTopDetail : materialTopDetail,
         materialHideDetail : materialHideDetail,
         reportHideDetail : reportHideDetail,
@@ -214,7 +217,7 @@ function save_options() {
         console.log("settings changed");
     });
     }
-    
+
     // Restores select box and checkbox state using the preferences
     // stored in chrome.storage.
     function restore_options() {
@@ -269,7 +272,7 @@ function save_options() {
         document.getElementById('exportIcs').checked = items.exportIcs;
         document.getElementById('highlightDeadline').checked = items.highlightDeadline;
         document.getElementById('pastSurvey').checked = items.pastSurvey;
-        document.getElementById('subjectListNum').textContent = items.subjectList;  
+        document.getElementById('subjectListNum').textContent = items.subjectList;
         document.getElementById('materialTop').checked = items.materialTop;
         document.getElementById('materialHide').checked = items.materialHide;
         document.getElementById('reportHide').checked = items.reportHide;
@@ -288,7 +291,7 @@ function save_options() {
         document.getElementById('gasTodo').checked = items.gasTodo;
         restoreSubject(items.subjectList);
     });
-    
+
     }
     document.addEventListener('DOMContentLoaded', restore_options);
     //チェックボックスが更新されたら保存
@@ -416,7 +419,7 @@ function save_options() {
                 event.preventDefault();
                 let id = event.dataTransfer.getData('text/plain');
                 let elm_drag = document.getElementById(id);
-        
+
                 let rect = this.getBoundingClientRect();
                 if ((event.clientY - rect.top) < (this.clientHeight / 2)) {
                     this.parentNode.insertBefore(elm_drag, this);

--- a/ScombZ Utilities/options/options.js
+++ b/ScombZ Utilities/options/options.js
@@ -277,6 +277,7 @@ function save_options() {
         document.getElementById('materialHide').checked = items.materialHide;
         document.getElementById('reportHide').checked = items.reportHide;
         document.getElementById('testHide').checked = items.testHide;
+        document.getElementById('modifyCoursePageTitle').checked = items.modifyCoursePageTitle;
         document.getElementById('materialTopDetail').value = items.materialTopDetail;
         document.getElementById('materialHideDetail').value = items.materialHideDetail;
         document.getElementById('reportHideDetail').value = items.reportHideDetail;


### PR DESCRIPTION
## 概要

ScombZ で科目ページへアクセスした時の `<title>` 要素の中身を `科目トップ` から `{科目名} - 科目トップ` に変更する機能を追加しました。設定の「**ページタイトルに科目名を表示**（`modifyCourseTitlePage`）」から，この機能の有効／無効を切り替え可能です（デフォルト：有効）。

※Microsoft Edge 107.0.1418.26 (Official build) (64-bit) で正しく動作することを確認済みです。

## スクリーンショット

例えば `微分方程式` という科目名なら，下図の黄枠部のように `微分方程式 - 科目トップ` と表示します。枠線の上にあるタブは，適用前との比較用です。

![適用例](https://user-images.githubusercontent.com/46659204/199729936-da708044-e98f-456e-93e0-934548fbe4a5.png)

