### PR TITLE
modifyCoursePageTitle で科目名が正しく表示されない不具合を修正

### DIFF
--- a/ScombZ Utilities/js/modifyCoursePageTitle.js
+++ b/ScombZ Utilities/js/modifyCoursePageTitle.js
@@ -6,8 +6,8 @@ function modifyCoursePageTitle() {
         '#courseTopForm > div.course-header > div:nth-child(1) > div.course-title-txt.course-view-header-txt'
     )
     if (isCourseTopPage && courseTitle) {
-        // 科目名
-        const courseName = courseTitle.textContent.split(' ').at(-1)
+        // 科目名を取得する。例えば、「学部 01CD456789 Course Name」のような文字列から科目名（この例では「Course Name」）を抽出する
+        const courseName = courseTitle.textContent.split(/ [0-9A-Za-z]{10} /).at(-1)
 
         // 「科目名 - 科目トップ」のような表示にする
         document.title = `${courseName} - ${document.title}`

--- a/ScombZ Utilities/js/modifyCoursePageTitle.js
+++ b/ScombZ Utilities/js/modifyCoursePageTitle.js
@@ -7,7 +7,9 @@ function modifyCoursePageTitle() {
     )
     if (isCourseTopPage && courseTitle) {
         // 科目名を取得する。例えば、「学部 01CD456789 Course Name」のような文字列から科目名（この例では「Course Name」）を抽出する
-        const courseName = courseTitle.textContent.split(/ [0-9A-Za-z]{10} /).at(-1)
+        const courseName = courseTitle.textContent
+            .split(/ [0-9A-Za-z]{10} /)
+            .at(-1)
 
         // 「科目名 - 科目トップ」のような表示にする
         document.title = `${courseName} - ${document.title}`


### PR DESCRIPTION
## 概要

- Close #127

Issue #127 の問題を修正しました。`courseTitle.textContent` の区切り文字を調整し，科目名に半角スペースが含まれている場合でも正しく取得できるようになっています。
