### PR TITLE
履修していない科目の科目ページに飛んだ際に起きるバグの修正

### DIFF
--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -447,6 +447,9 @@ function createButton(className,materials,mode){
 function addTaskPage() {
     'use strict';
     if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+        if (!document.getElementById("report")){
+            return;
+        }
         let cssPosition = document.getElementById("report").getElementsByTagName("div")[0];
         //要素あるかチェック
         if (!(cssPosition)){
@@ -460,7 +463,6 @@ function addTaskPage() {
         `);
 
         let subjectName = document.getElementsByClassName("course-title-txt")[0].textContent.split(" ").slice(2).join(" ");
-        alert(subjectName);
         
         //追加ボタンを押したときに代入
         $(function(){

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -71,7 +71,12 @@ function hideMaterial(items,materialTop) {
         console.log("教材を一部非表示");
         let [materialOrder,materialListBlock] = materialBlockCreate();
         let cssPosition = document.getElementById("materialList");
-        setcss(cssPosition);
+        if (cssPosition){
+            setcss(cssPosition);
+        }else{
+            return;
+        }
+        
         
         if (materialTop != 'none'){
             materialOrder = materialTop;
@@ -98,6 +103,8 @@ function hideMaterial(items,materialTop) {
             }
             else if (materialOrder == 'first'){
                 lastMaterial = materialListBlock.pop();
+            }else{
+                return;
             }
 
             let materialButton = createButton("close-button",lastMaterial.slice(1),"material");


### PR DESCRIPTION
### 内容
バグ修正。
検索ページから履修していない科目のページなどに飛ぶと、普通ならあるはずの教材欄などがないためバグが発生したため、その周りの修正を行った。
具体的には、それらの欄があるかを調べ、ない場合はreturnで戻るようにしている。