### PR TITLE
アンケート回答完了ページ等で「アンケート一覧に戻る」ボタンを追加する

### DIFF
--- a/ScombZ Utilities/js/styleSurveys.js
+++ b/ScombZ Utilities/js/styleSurveys.js
@@ -138,7 +138,7 @@ function pastSurvey(){
     }
 }
 
-function insertSurveyListButton() {
+function addSurveyListButton() {
     // 「科目トップに戻る」ボタン
     const backButton =
         document.getElementById("backManagement") ??

--- a/ScombZ Utilities/js/styleSurveys.js
+++ b/ScombZ Utilities/js/styleSurveys.js
@@ -137,3 +137,31 @@ function pastSurvey(){
         });
     }
 }
+
+function insertSurveyListButton() {
+    // 「科目トップに戻る」ボタン
+    const backButton =
+        document.getElementById("backManagement") ??
+        document.querySelector(
+            "#surveysTakeForm > div.block-under-area > div > div > a"
+        );
+
+    // アンケート回答完了ページ等かを判定する
+    const isCompleted =
+        location.hostname === "scombz.shibaura-it.ac.jp" &&
+        location.pathname === "/lms/course/surveys/take" &&
+        backButton !== null;
+
+    if (isCompleted) {
+        // 「科目トップに戻る」ボタンを基に「アンケート一覧に戻る」ボタンを生成する
+        console.log("「アンケート一覧に戻る」ボタンを生成します")
+        const surveyListButton = backButton.cloneNode(true);
+        surveyListButton.id = "backSurveys";
+        surveyListButton.href = "/portal/surveys/list";
+        surveyListButton.textContent = "アンケート一覧に戻る";
+
+        // 「科目トップに戻る」ボタンの隣に「アンケート一覧に戻る」ボタンを追加する
+        backButton.after(surveyListButton);
+        console.log("「アンケート一覧に戻る」ボタンを追加しました")
+    }
+}

--- a/ScombZ Utilities/main.js
+++ b/ScombZ Utilities/main.js
@@ -42,6 +42,7 @@
             dadbugFix: true,            //ドラッグ&ドロップで提出できないバグを修正
             attendance: 'none',         //出席記録を消す
             pastSurvey: true,           //過去のアンケート
+            surveyListButton: true,     //「アンケート一覧に戻る」ボタン
             adjustTimetableData:{       // LMSの調整
                 eraseSat: false,        // 土曜日を消す
                 erase6: false,          // 6限を消す
@@ -210,6 +211,10 @@
                 //アンケートに過去のアンケートを表示
                 if(items.pastSurvey === true){
                     pastSurvey();
+                }
+                //アンケートの完了画面に「アンケート一覧に戻る」ボタンを表示する
+                if(items.surveyListButton === true){
+                    insertSurveyListButton();
                 }
                 //科目ページの要素並び替え
                 if(items.subjectList !== '12345678'){

--- a/ScombZ Utilities/main.js
+++ b/ScombZ Utilities/main.js
@@ -214,7 +214,7 @@
                 }
                 //アンケートの完了画面に「アンケート一覧に戻る」ボタンを表示する
                 if(items.surveyListButton === true){
-                    insertSurveyListButton();
+                    addSurveyListButton();
                 }
                 //科目ページの要素並び替え
                 if(items.subjectList !== '12345678'){

--- a/ScombZ Utilities/options/options.html
+++ b/ScombZ Utilities/options/options.html
@@ -45,7 +45,7 @@
             <div class="input-box">
                 <h3>設定インポート</h3>
                 <input type="file" accept=".json" id="import-json">
-            </div>  
+            </div>
             <hr>
             <h1 class="subtitle">基本設定</h1>
             <hr>
@@ -452,6 +452,13 @@
                 <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="pastSurvey"><label class="ItemBox-CheckBox-Label" for="pastSurvey"></label>
                 <div class="explains">
                     アンケート一覧ページの下部に、過去のアンケート一覧を表示します。<br>このデータは拡張機能本体に累積されていくので、拡張機能導入より前のデータや、拡張機能が一度も読み取れなかったデータにはアクセスできません。
+                </div>
+            </div>
+            <div class="setting-column">
+                <h3>「アンケート一覧に戻る」ボタンの表示</h3><span class="id-explain">insertSurveyListButton</span>
+                <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="insertSurveyListButton"><label class="ItemBox-CheckBox-Label" for="insertSurveyListButton"></label>
+                <div class="explains">
+                    アンケートの完了画面で「科目トップに戻る」ボタンの隣に「アンケート一覧に戻る」ボタンを表示します。
                 </div>
             </div>
             <div class="setting-column">

--- a/ScombZ Utilities/options/options.html
+++ b/ScombZ Utilities/options/options.html
@@ -455,8 +455,8 @@
                 </div>
             </div>
             <div class="setting-column">
-                <h3>「アンケート一覧に戻る」ボタンの表示</h3><span class="id-explain">insertSurveyListButton</span>
-                <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="insertSurveyListButton"><label class="ItemBox-CheckBox-Label" for="insertSurveyListButton"></label>
+                <h3>「アンケート一覧に戻る」ボタンの表示</h3><span class="id-explain">addSurveyListButton</span>
+                <input  class="ItemBox-CheckBox-Input"  type="checkbox" id="addSurveyListButton"><label class="ItemBox-CheckBox-Label" for="addSurveyListButton"></label>
                 <div class="explains">
                     アンケートの完了画面で「科目トップに戻る」ボタンの隣に「アンケート一覧に戻る」ボタンを表示します。
                 </div>

--- a/ScombZ Utilities/options/options.js
+++ b/ScombZ Utilities/options/options.js
@@ -38,7 +38,7 @@ const defaultOptions = {
     exportIcs: true,
     attendance: 'none',
     pastSurvey: true,
-    insertSurveyListButton: true,
+    addSurveyListButton: true,
     highlightDeadline: true,
     adjustTimetableData : {
         eraseSat : false,
@@ -124,7 +124,7 @@ function save_options() {
     const exportIcs = document.getElementById('exportIcs').checked;
     const highlightDeadline = document.getElementById('highlightDeadline').checked;
     const pastSurvey = document.getElementById('pastSurvey').checked;
-    const insertSurveyListButton = document.getElementById('insertSurveyListButton').checked;
+    const addSurveyListButton = document.getElementById('addSurveyListButton').checked;
     const subjectList = document.getElementById('subjectListNum').textContent;
     const materialTop = document.getElementById('materialTop').checked;
     const materialHide = document.getElementById('materialHide').checked;
@@ -185,7 +185,7 @@ function save_options() {
         exportIcs : exportIcs,
         highlightDeadline : highlightDeadline,
         pastSurvey : pastSurvey,
-        insertSurveyListButton : insertSurveyListButton,
+        addSurveyListButton : addSurveyListButton,
         adjustTimetableData : {
             eraseSat : eraseSat,
             erase6 : erase6,
@@ -278,7 +278,7 @@ function save_options() {
         document.getElementById('exportIcs').checked = items.exportIcs;
         document.getElementById('highlightDeadline').checked = items.highlightDeadline;
         document.getElementById('pastSurvey').checked = items.pastSurvey;
-        document.getElementById('insertSurveyListButton').checked = items.insertSurveyListButton;
+        document.getElementById('addSurveyListButton').checked = items.addSurveyListButton;
         document.getElementById('subjectListNum').textContent = items.subjectList;
         document.getElementById('materialTop').checked = items.materialTop;
         document.getElementById('materialHide').checked = items.materialHide;

--- a/ScombZ Utilities/options/options.js
+++ b/ScombZ Utilities/options/options.js
@@ -38,6 +38,7 @@ const defaultOptions = {
     exportIcs: true,
     attendance: 'none',
     pastSurvey: true,
+    insertSurveyListButton: true,
     highlightDeadline: true,
     adjustTimetableData : {
         eraseSat : false,
@@ -123,6 +124,7 @@ function save_options() {
     const exportIcs = document.getElementById('exportIcs').checked;
     const highlightDeadline = document.getElementById('highlightDeadline').checked;
     const pastSurvey = document.getElementById('pastSurvey').checked;
+    const insertSurveyListButton = document.getElementById('insertSurveyListButton').checked;
     const subjectList = document.getElementById('subjectListNum').textContent;
     const materialTop = document.getElementById('materialTop').checked;
     const materialHide = document.getElementById('materialHide').checked;
@@ -183,6 +185,7 @@ function save_options() {
         exportIcs : exportIcs,
         highlightDeadline : highlightDeadline,
         pastSurvey : pastSurvey,
+        insertSurveyListButton : insertSurveyListButton,
         adjustTimetableData : {
             eraseSat : eraseSat,
             erase6 : erase6,
@@ -275,6 +278,7 @@ function save_options() {
         document.getElementById('exportIcs').checked = items.exportIcs;
         document.getElementById('highlightDeadline').checked = items.highlightDeadline;
         document.getElementById('pastSurvey').checked = items.pastSurvey;
+        document.getElementById('insertSurveyListButton').checked = items.insertSurveyListButton;
         document.getElementById('subjectListNum').textContent = items.subjectList;
         document.getElementById('materialTop').checked = items.materialTop;
         document.getElementById('materialHide').checked = items.materialHide;
@@ -467,7 +471,7 @@ function save_options() {
                 //クリックしたら即リンクタグを消す
                 document.body.removeChild(link);
                 delete link;
-            
+
         })
     });
     //インポート


### PR DESCRIPTION
## 概要

アンケートの回答完了時などのページで「科目トップに戻る」ボタンの隣に「アンケート一覧に戻る」ボタンを追加します（cf. スクリーンショット）。自己評価アンケートに回答したり，アンケートのエラーページから戻ったりするときは，科目トップよりもアンケート一覧に戻りたいケースが多そうなので実装しました。

実際にアンケート回答をして正しく動作することを検証済みです。

## スクリーンショット

※ScombZ Utilities によるスタイル変更を無効化した状態で撮影しています。

![動作例](https://user-images.githubusercontent.com/46659204/217149480-f44297a6-e6fc-42a4-ae0d-186c8fcfbf5a.png)
