### PR TITLE
科目ページのURLで発生しているバグの修正&エンター出席バグの関数変更

### DIFF
--- a/ScombZ Utilities/js/attendance.js
+++ b/ScombZ Utilities/js/attendance.js
@@ -4,7 +4,7 @@
 //3つのモード
 function attendanceRemove(item){
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         if (item === 'only'){
             console.log("※表示の場合出席を削除");
             let attendanceKome = document.querySelector("#attendance > div.block-contents > div > div:nth-child(3) > div:nth-child(1) > div.course-view-attendance-status > label");

--- a/ScombZ Utilities/js/attendance.js
+++ b/ScombZ Utilities/js/attendance.js
@@ -4,7 +4,7 @@
 //3つのモード
 function attendanceRemove(item){
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         if (item === 'only'){
             console.log("※表示の場合出席を削除");
             let attendanceKome = document.querySelector("#attendance > div.block-contents > div > div:nth-child(3) > div:nth-child(1) > div.course-view-attendance-status > label");

--- a/ScombZ Utilities/js/getTaskLists.js
+++ b/ScombZ Utilities/js/getTaskLists.js
@@ -129,7 +129,7 @@ function getTasksByAdjax($$reacquisitionMin){
 
 //アンケートを取得するかどうかの設定を科目別ページに挿入
 function insertSurveyBtnOnSubj(){
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?idnumber=')){
+    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course')){
         const $courseTitle = document.querySelector('.course-title-txt');
         if($courseTitle && !document.getElementById("noticeSurvey")){
             console.log('授業別ページを検出しました\nアンケート取得是非を挿入します');

--- a/ScombZ Utilities/js/getTaskLists.js
+++ b/ScombZ Utilities/js/getTaskLists.js
@@ -129,7 +129,7 @@ function getTasksByAdjax($$reacquisitionMin){
 
 //アンケートを取得するかどうかの設定を科目別ページに挿入
 function insertSurveyBtnOnSubj(){
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?idnumber=')){
+    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?')){
         const $courseTitle = document.querySelector('.course-title-txt');
         if($courseTitle && !document.getElementById("noticeSurvey")){
             console.log('授業別ページを検出しました\nアンケート取得是非を挿入します');

--- a/ScombZ Utilities/js/layout.js
+++ b/ScombZ Utilities/js/layout.js
@@ -41,7 +41,7 @@ function changeLogout() {
 //ページ最大横幅
 function maxWidthOnSubjPage() {
     'use strict';
-    if (location.href.includes("lms/course?idnumber=") && location.href.length < 80) {
+    if (location.href.includes("lms/course") && location.href.length < 80) {
         console.log('科目ページの最大横幅を変更します');
         chrome.storage.local.get({
             maxWidthPx: {

--- a/ScombZ Utilities/js/layout.js
+++ b/ScombZ Utilities/js/layout.js
@@ -41,7 +41,7 @@ function changeLogout() {
 //ページ最大横幅
 function maxWidthOnSubjPage() {
     'use strict';
-    if (location.href.includes("lms/course?idnumber=") && location.href.length < 80) {
+    if (location.href.includes("lms/course?") && location.href.length < 80) {
         console.log('科目ページの最大横幅を変更します');
         chrome.storage.local.get({
             maxWidthPx: {

--- a/ScombZ Utilities/js/layout.js
+++ b/ScombZ Utilities/js/layout.js
@@ -41,7 +41,7 @@ function changeLogout() {
 //ページ最大横幅
 function maxWidthOnSubjPage() {
     'use strict';
-    if (location.href.includes("lms/course?") && location.href.length < 80) {
+    if (location.href.includes("scombz.shibaura-it.ac.jp/lms/course?")) {
         console.log('科目ページの最大横幅を変更します');
         chrome.storage.local.get({
             maxWidthPx: {

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -13,7 +13,7 @@
 //要素並び替え
 function subjectListOrder(items) {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         console.log("科目ページの要素並び替え");
         let subjectdivs = [];
         subjectdivs.push(document.getElementById("message"));
@@ -42,7 +42,7 @@ function subjectListOrder(items) {
 //教材の順番統一
 function materialTopSet(items) {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
 
         let materialList = document.querySelectorAll("#materialList > div");
         const firstmaterial = materialList[0];
@@ -70,7 +70,7 @@ function materialTopSet(items) {
 //教材を一部非表示化
 function hideMaterial(items,materialTop) {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         console.log("教材を一部非表示");
         let [materialOrder,materialListBlock] = materialBlockCreate();
         let cssPosition = document.getElementById("materialList");
@@ -159,7 +159,7 @@ function sortMaterials(item){
 //課題を一部非表示化
 function hideReport(items){
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
 
         let cssPosition = document.getElementById("reportList");
         if (!(cssPosition)){
@@ -201,7 +201,7 @@ function hideReport(items){
 //テストを一部非表示化
 function hideTest(items){
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         let cssPosition = document.getElementById("examination");
         if (!(cssPosition)){
             return;
@@ -453,7 +453,7 @@ function createButton(className,materials,mode){
 //課題手動追加を科目ページから呼び出す
 function addTaskPage() {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         if (!document.getElementById("report")){
             return;
         }

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -505,6 +505,11 @@ function addTaskButton(addTaskTimes, addTaskDates){
     setTimeout(function(){
 
         let addTaskPosition = document.querySelector("#manAddtaskSelectLayer > form > div:nth-child(3)");
+
+        if (!addTaskPosition){
+            return;
+        }
+
         //日～土+今日+明日
         const addTaskDateData = [...Array(7)].map((_, i) =>getNextDay(i));
         addTaskDateData.push(new Date());

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -13,7 +13,7 @@
 //要素並び替え
 function subjectListOrder(items) {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         console.log("科目ページの要素並び替え");
         let subjectdivs = [];
         subjectdivs.push(document.getElementById("message"));
@@ -42,7 +42,7 @@ function subjectListOrder(items) {
 //教材の順番統一
 function materialTopSet(items) {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
 
         let materialList = document.querySelectorAll("#materialList > div");
         const firstmaterial = materialList[0];
@@ -70,7 +70,7 @@ function materialTopSet(items) {
 //教材を一部非表示化
 function hideMaterial(items,materialTop) {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         console.log("教材を一部非表示");
         let [materialOrder,materialListBlock] = materialBlockCreate();
         let cssPosition = document.getElementById("materialList");
@@ -159,7 +159,7 @@ function sortMaterials(item){
 //課題を一部非表示化
 function hideReport(items){
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
 
         let cssPosition = document.getElementById("reportList");
         if (!(cssPosition)){
@@ -201,7 +201,7 @@ function hideReport(items){
 //テストを一部非表示化
 function hideTest(items){
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         let cssPosition = document.getElementById("examination");
         if (!(cssPosition)){
             return;
@@ -453,7 +453,7 @@ function createButton(className,materials,mode){
 //課題手動追加を科目ページから呼び出す
 function addTaskPage() {
     'use strict';
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         if (!document.getElementById("report")){
             return;
         }

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -79,7 +79,7 @@ function hideMaterial(items,materialTop) {
         }
 
         setcss(cssPosition);
-        
+
         if (materialTop != 'none'){
             materialOrder = materialTop;
         }
@@ -181,7 +181,7 @@ function hideReport(items){
         }
 
         sortMaterials(materials[0].parentNode);
-        
+
         const hides = cssPosition.getElementsByClassName("hide-material");
         if(hides[0]){
             let buttonDiv = document.querySelector("#reportList > div")
@@ -224,7 +224,7 @@ function hideTest(items){
         let reportList = document.querySelector("#examination > div.block-contents > div > div:nth-child(2)");
 
         sortMaterials(materials[0].parentNode);
-        
+
         const hides = cssPosition.getElementsByClassName("hide-material");
         if(hides[0]){
             let buttonDiv = document.querySelector("#examination > div.block-contents > div > div")
@@ -486,7 +486,7 @@ function autoTaskInput(){
         if(!buttonPositon){
             return;
         }
-        document.querySelector("#manAddtaskSelectLayer > form > div:nth-child(4) > button:nth-child(2)").insertAdjacentHTML("beforebegin", 
+        document.querySelector("#manAddtaskSelectLayer > form > div:nth-child(4) > button:nth-child(2)").insertAdjacentHTML("beforebegin",
         `
         <button type="button" id="subAutoInput">自動入力</button>
         `
@@ -495,7 +495,7 @@ function autoTaskInput(){
         autoInputButton.addEventListener("click", subAutoInput);
 
     },2000);
-    
+
 
 }
 
@@ -545,13 +545,13 @@ function addTaskButton(addTaskTimes, addTaskDates){
                 let button = document.createElement("button");
                 button.type = "button";
                 button.textContent = addTaskDateText[i];
-                
+
                 $(button).on("click", function(){
                     //凄い良いアイデアだったけどUTCで取り扱われるから断念
                     //document.getElementById("manAddtaskDeadlineDate").valueAsDate = addTaskDateData[i];
-                    
+
                     document.getElementById("manAddtaskDeadlineDate").value = addTaskDateData[i].getFullYear() +"-"+( '00' + (addTaskDateData[i].getMonth()+1) ).slice( -2 ) + "-" + ( '00' + addTaskDateData[i].getDate()) .slice( -2 );
-                    
+
                 });
 
                 addTaskPosition.appendChild(button);
@@ -561,8 +561,8 @@ function addTaskButton(addTaskTimes, addTaskDates){
 
     },2000);
 
-    
-    
+
+
 }
 
 //科目ページとURLを自作課題欄に入力する関数
@@ -582,41 +582,47 @@ function enterAttendanceDebug(){
     //form内にinput[type="text"]が1個しかないのが原因なため、見えないinputを追加する
     //ただ、元々エンターで送信していたことを潰したくないため、ボタンを押したときと同じ処理を行う
 
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
+        const callback = (mutations) => {
+            mutations.forEach((mutation) => {
 
-    const callback = (mutations) => {
-        mutations.forEach((mutation) => {
+                //変更検知してもまだ処理が行われていない可能性があるため
+                if (document.querySelector("#attendancesSendForm") != null){
+                    //ボタンがなかったら
+                    if (!document.querySelector("#attendancesSendFakeButton")){
+                            let fakeButton = document.createElement("input");
+                            fakeButton.type = "text";
+                            fakeButton.id = "attendancesSendFakeButton";
+                            document.querySelector("#attendancesSendForm > div.contents-hidden").appendChild(fakeButton);
+                            //ここで追加
 
-            //変更検知してもまだ処理が行われていない可能性があるため
-            if (document.querySelector("#attendancesSendForm") != null){
-                //ボタンがなかったら
-                if (!document.querySelector("#attendancesSendFakeButton")){
-                        let fakeButton = document.createElement("input");
-                        fakeButton.type = "text";
-                        fakeButton.id = "attendancesSendFakeButton";
-                        document.querySelector("#attendancesSendForm > div.contents-hidden").appendChild(fakeButton);
-                        //ここで追加
-
-                }
-                //エンターで送信する
-                $("#attendancesSendForm > div.contents-list > div:nth-child(4) > div.contents-input-area > input").keydown(function(e) {
-                    if (e.code == "Enter"){
-                        //送信ボタンをクリックさせる
-                        let attendanceSubmitButton = document.querySelectorAll("body > div > div > div > button");
-                        attendanceSubmitButton[1].click();
                     }
+                    //エンターで送信する
+                    $("#attendancesSendForm > div.contents-list > div:nth-child(4) > div.contents-input-area > input").keydown(function(e) {
+                        if (e.code == "Enter"){
+                            //送信ボタンをクリックさせる
+                            let attendanceSubmitButton = document.querySelectorAll("body > div > div > div > button");
+                            attendanceSubmitButton[1].click();
+                        }
 
-                });
-            }
-        })
+                    });
+                }
+            })
+        }
+        const observer = new MutationObserver(callback);
+        const target = document.querySelector("#attendances_send_set");
+        const config = {
+            childList: true,
+            attributes: true,
+            characterData: true,
+            subtree: true,
+        };
+
+        if (target){
+            return;
+        }
+
+        observer.observe(target, config);
+
     }
-    const observer = new MutationObserver(callback);
-    const target = document.querySelector("#attendances_send_set");
-    const config = {
-        childList: true, 
-        attributes: true,  
-        characterData: true,
-        subtree: true, 
-    };
-    
-    observer.observe(target, config);
 }

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -582,31 +582,41 @@ function enterAttendanceDebug(){
     //form内にinput[type="text"]が1個しかないのが原因なため、見えないinputを追加する
     //ただ、元々エンターで送信していたことを潰したくないため、ボタンを押したときと同じ処理を行う
 
-    //変更を検知
-    $("#attendances_send_set").on('DOMSubtreeModified propertychange',function(){
-        
-        //変更検知してもまだ処理が行われていない可能性があるため
-        if (document.querySelector("#attendancesSendForm") != null){
-            //ボタンがなかったら
-            if (!document.querySelector("#attendancesSendFakeButton")){
-                    let fakeButton = document.createElement("input");
-                    fakeButton.type = "text";
-                    fakeButton.id = "attendancesSendFakeButton";
-                    document.querySelector("#attendancesSendForm > div.contents-hidden").appendChild(fakeButton);
-                    //ここで追加
 
-            }
-            //エンターで送信する
-            $("#attendancesSendForm > div.contents-list > div:nth-child(4) > div.contents-input-area > input").keydown(function(e) {
-                if (e.code == "Enter"){
-                    //送信ボタンをクリックさせる
-                    let attendanceSubmitButton = document.querySelectorAll("body > div > div > div > button");
-                    attendanceSubmitButton[1].click();
+    const callback = (mutations) => {
+        mutations.forEach((mutation) => {
+
+            //変更検知してもまだ処理が行われていない可能性があるため
+            if (document.querySelector("#attendancesSendForm") != null){
+                //ボタンがなかったら
+                if (!document.querySelector("#attendancesSendFakeButton")){
+                        let fakeButton = document.createElement("input");
+                        fakeButton.type = "text";
+                        fakeButton.id = "attendancesSendFakeButton";
+                        document.querySelector("#attendancesSendForm > div.contents-hidden").appendChild(fakeButton);
+                        //ここで追加
+
                 }
+                //エンターで送信する
+                $("#attendancesSendForm > div.contents-list > div:nth-child(4) > div.contents-input-area > input").keydown(function(e) {
+                    if (e.code == "Enter"){
+                        //送信ボタンをクリックさせる
+                        let attendanceSubmitButton = document.querySelectorAll("body > div > div > div > button");
+                        attendanceSubmitButton[1].click();
+                    }
 
-            });
-        }
-
-        
-    })
+                });
+            }
+        })
+    }
+    const observer = new MutationObserver(callback);
+    const target = document.querySelector("#attendances_send_set");
+    const config = {
+        childList: true, 
+        attributes: true,  
+        characterData: true,
+        subtree: true, 
+    };
+    
+    observer.observe(target, config);
 }

--- a/ScombZ Utilities/js/layoutSubject.js
+++ b/ScombZ Utilities/js/layoutSubject.js
@@ -618,7 +618,7 @@ function enterAttendanceDebug(){
             subtree: true,
         };
 
-        if (target){
+        if (!target){
             return;
         }
 

--- a/ScombZ Utilities/js/notepad.js
+++ b/ScombZ Utilities/js/notepad.js
@@ -328,7 +328,7 @@ function displayNotepad(){
     return;
 }
 function addMarkdownToSubj(){
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         // URLを取得
         const pageurl = new URL(window.location.href);
         const idnum = pageurl.searchParams.get('idnumber');

--- a/ScombZ Utilities/js/notepad.js
+++ b/ScombZ Utilities/js/notepad.js
@@ -328,7 +328,7 @@ function displayNotepad(){
     return;
 }
 function addMarkdownToSubj(){
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         // URLを取得
         const pageurl = new URL(window.location.href);
         const idnum = pageurl.searchParams.get('idnumber');

--- a/ScombZ Utilities/js/styleSidemenu.js
+++ b/ScombZ Utilities/js/styleSidemenu.js
@@ -171,7 +171,7 @@ function styleSidemenu(){
     </style>
     `);
     //LMSページ飛び出る問題
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
         const contentsDetails = document.querySelectorAll(".contents-detail");
         for(const contentsDetail of contentsDetails){
             if(contentsDetail.parentNode.parentNode && contentsDetail.parentNode.parentNode.classList.contains("block") && contentsDetail.parentNode.parentNode.classList.contains("clearfix")){

--- a/ScombZ Utilities/js/styleSidemenu.js
+++ b/ScombZ Utilities/js/styleSidemenu.js
@@ -171,7 +171,7 @@ function styleSidemenu(){
     </style>
     `);
     //LMSページ飛び出る問題
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=")){
+    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
         const contentsDetails = document.querySelectorAll(".contents-detail");
         for(const contentsDetail of contentsDetails){
             if(contentsDetail.parentNode.parentNode && contentsDetail.parentNode.parentNode.classList.contains("block") && contentsDetail.parentNode.parentNode.classList.contains("clearfix")){

--- a/ScombZ Utilities/js/styleSidemenu.js
+++ b/ScombZ Utilities/js/styleSidemenu.js
@@ -171,11 +171,7 @@ function styleSidemenu(){
     </style>
     `);
     //LMSページ飛び出る問題
-<<<<<<< HEAD
     if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?")){
-=======
-    if(location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course")){
->>>>>>> f00f4c07465ca913f4c1a9b9b8ee2d47c8ed2cc7
         const contentsDetails = document.querySelectorAll(".contents-detail");
         for(const contentsDetail of contentsDetails){
             if(contentsDetail.parentNode.parentNode && contentsDetail.parentNode.parentNode.classList.contains("block") && contentsDetail.parentNode.parentNode.classList.contains("clearfix")){

--- a/ScombZ Utilities/js/supportFunctions.js
+++ b/ScombZ Utilities/js/supportFunctions.js
@@ -26,7 +26,7 @@ function getNowPeriod(){
 }
 //課題一覧のアンケートからリンクしたときにアンケートまでスクロールしてくれるようにする関数
 function surveyLinkScroll() {
-    if (location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=") && location.href.includes("questionnaire")){
+    if (location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?") && location.href.includes("questionnaire")){
         setTimeout(function(){
             window.location.href = ("#questionnaire");
         },300);

--- a/ScombZ Utilities/js/supportFunctions.js
+++ b/ScombZ Utilities/js/supportFunctions.js
@@ -26,11 +26,7 @@ function getNowPeriod(){
 }
 //課題一覧のアンケートからリンクしたときにアンケートまでスクロールしてくれるようにする関数
 function surveyLinkScroll() {
-<<<<<<< HEAD
     if (location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?") && location.href.includes("questionnaire")){
-=======
-    if (location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course") && location.href.includes("questionnaire")){
->>>>>>> f00f4c07465ca913f4c1a9b9b8ee2d47c8ed2cc7
         setTimeout(function(){
             window.location.href = ("#questionnaire");
         },300);

--- a/ScombZ Utilities/js/supportFunctions.js
+++ b/ScombZ Utilities/js/supportFunctions.js
@@ -26,7 +26,7 @@ function getNowPeriod(){
 }
 //課題一覧のアンケートからリンクしたときにアンケートまでスクロールしてくれるようにする関数
 function surveyLinkScroll() {
-    if (location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course?idnumber=") && location.href.includes("questionnaire")){
+    if (location.href.includes("https://scombz.shibaura-it.ac.jp/lms/course") && location.href.includes("questionnaire")){
         setTimeout(function(){
             window.location.href = ("#questionnaire");
         },300);

--- a/ScombZ Utilities/js/syllBtn.js
+++ b/ScombZ Utilities/js/syllBtn.js
@@ -2,11 +2,7 @@
 /* syllBtn.js */
 function displaySyllabus(year , fac){
     'use strict';
-<<<<<<< HEAD
     if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?')){
-=======
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course')){
->>>>>>> f00f4c07465ca913f4c1a9b9b8ee2d47c8ed2cc7
         console.log('授業別ページを検出しました\nシラバスのデータと連携します');
         const $courseTitle = document.querySelector('.course-title-txt');
         if($courseTitle){
@@ -62,11 +58,7 @@ function displaySyllabus(year , fac){
 }
 function displaySyllabusError(){
     'use strict';
-<<<<<<< HEAD
     if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?')){
-=======
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course')){
->>>>>>> f00f4c07465ca913f4c1a9b9b8ee2d47c8ed2cc7
         const $courseTitle = document.querySelector('.course-title-txt');
         $courseTitle.parentNode.insertAdjacentHTML('beforeEnd',`<span style="color:red;padding: 12px 30px 10px 34px">シラバス表示をするには、<a href="javascript:void(0);" id="link_to_extention_syll">拡張機能設定</a>から、学年と学部を設定してください。</span>`);
         document.getElementById("link_to_extention_syll").addEventListener("click", function(){

--- a/ScombZ Utilities/js/syllBtn.js
+++ b/ScombZ Utilities/js/syllBtn.js
@@ -2,7 +2,7 @@
 /* syllBtn.js */
 function displaySyllabus(year , fac){
     'use strict';
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?idnumber=')){
+    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course')){
         console.log('授業別ページを検出しました\nシラバスのデータと連携します');
         const $courseTitle = document.querySelector('.course-title-txt');
         if($courseTitle){
@@ -58,7 +58,7 @@ function displaySyllabus(year , fac){
 }
 function displaySyllabusError(){
     'use strict';
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?idnumber=')){
+    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course')){
         const $courseTitle = document.querySelector('.course-title-txt');
         $courseTitle.parentNode.insertAdjacentHTML('beforeEnd',`<span style="color:red;padding: 12px 30px 10px 34px">シラバス表示をするには、<a href="javascript:void(0);" id="link_to_extention_syll">拡張機能設定</a>から、学年と学部を設定してください。</span>`);
         document.getElementById("link_to_extention_syll").addEventListener("click", function(){

--- a/ScombZ Utilities/js/syllBtn.js
+++ b/ScombZ Utilities/js/syllBtn.js
@@ -2,7 +2,7 @@
 /* syllBtn.js */
 function displaySyllabus(year , fac){
     'use strict';
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?idnumber=')){
+    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?')){
         console.log('授業別ページを検出しました\nシラバスのデータと連携します');
         const $courseTitle = document.querySelector('.course-title-txt');
         if($courseTitle){
@@ -58,7 +58,7 @@ function displaySyllabus(year , fac){
 }
 function displaySyllabusError(){
     'use strict';
-    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?idnumber=')){
+    if (location.href.includes('scombz.shibaura-it.ac.jp/lms/course?')){
         const $courseTitle = document.querySelector('.course-title-txt');
         $courseTitle.parentNode.insertAdjacentHTML('beforeEnd',`<span style="color:red;padding: 12px 30px 10px 34px">シラバス表示をするには、<a href="javascript:void(0);" id="link_to_extention_syll">拡張機能設定</a>から、学年と学部を設定してください。</span>`);
         document.getElementById("link_to_extention_syll").addEventListener("click", function(){


### PR DESCRIPTION
## 概要

- [x] 主に、科目ページURL指定で使われる?idnumber= を?のみに変更
- [x] Twitterで呟いていたURLの長さで制限をかけていたものの廃止
- [x] エンター出席バグの修正に使っていた関数を新しいものに変更

## 破壊的変更があるか(あれば内容を記載)

- [x] YES
科目ページかどうか判断するのに?idnumberを使わないように、全体を修正

## チェック項目

- [x] ビルドが通る
- [x] 作成した機能が想定通りに動作する
- [x] スマートフォンサイズで表示確認を行った
- [x] warning が増えていない
- [x] 複雑なコードにはコメントを記載してある

## リリースノートへの記述
### 種別
- [x] optimisation - 既存機能修正・最適化

### タイトル
一部機能の修正

### 詳細
一部の非推奨関数の最適化を行いました。

### 種別
- [x] bugfix - バグ修正

### タイトル
科目ページにおける問題の修正

### 詳細
特定の状況において科目ページ内の機能が上手く働かない問題を修正しました。

## 関連Issue
Issue #161 Fixed.

## コメント
ワーニングが増えていたので出席バグ周りの方の問題も修正しました。
正しく動作するはずですが、実際に出席が使える状況になってみないと微妙です。